### PR TITLE
HasOneOrMany::save() must be an instance of Model

### DIFF
--- a/src/Accountable.php
+++ b/src/Accountable.php
@@ -16,9 +16,11 @@ trait Accountable
 
     public function createAccount(string $name, string $description)
     {
-        return $this->accounts()->save([
+        $account = new LedgerAccount([
             'name'        => $name,
             'description' => $description,
         ]);
+
+        return $this->accounts()->save($account);
     }
 }


### PR DESCRIPTION
Fixed: Argument 1 passed to Illuminate\Database\Eloquent\Relations\HasOneOrMany::save() must be an instance of Illuminate\Database\Eloquent\Model, array given, called .../Traits/Accountable.php on line 32